### PR TITLE
Fix an important issue in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ if (Meteor.isServer) {
     // Normal Meteor publish call, the server always
     // controls what each client can see
     Meteor.publish('allJobs', function () {
-      myJobs.find({});
+      return myJobs.find({});
     });
 
     // Start the myJobs queue running


### PR DESCRIPTION
The example code that publishes `allJobs` should be returning the collection cursor, not just calling `myJobs.find()`.

Otherwise, Meteor will never consider the collection as ready and the whole code on the client side will fail.

PS: `myJobs.find()` is equivalent to `myJobs.find({}`.
