### PR TITLE
Fix `log()` on jobs without `runId` by loosening check in `jobLog()`

### DIFF
--- a/src/shared.coffee
+++ b/src/shared.coffee
@@ -900,7 +900,7 @@ class JobCollectionBase extends Mongo.Collection
 
   _DDPMethod_jobLog: (id, runId, message, options) ->
     check id, Match.Where(_validId)
-    check runId, Match.Where(_validId)
+    check runId, Match.OneOf(Match.Where(_validId), null)
     check message, String
     check options, Match.Optional
       level: Match.Optional(Match.Where _validLogLevel)


### PR DESCRIPTION
A job log may contain null `runId` entries (see `_validLog()`).  A job
that is not yet running has no `runId`.  To allow logging on such a job,
loosen the check in `jobLog()`.