### PR TITLE
Missing job.fail() behavior for dependent jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,7 +1250,8 @@ job.done("Done!");
 
 The job's next state depends on how its `job.retry()` settings are configured. It will either become
 `'failed'` or go to `'waiting'` for the next retry. `error` is any EJSON object and will be saved as
-an object. If passed error is not an object, it will be wrapped in one.
+an object. If passed error is not an object, it will be wrapped in one. If the job becomes `'failed'`,
+all dependent jobs will be cancelled.
 
 `options:`
 


### PR DESCRIPTION
According to the [code](https://github.com/vsivsi/meteor-job-collection/blob/master/src/shared.coffee#L1187), when the new status is "failed" then all dependent jobs are cancelled.