### PR TITLE
Keep progress information on done or fail

### DIFF
--- a/src/shared.coffee
+++ b/src/shared.coffee
@@ -1011,7 +1011,6 @@ class JobCollectionBase extends Mongo.Collection
         fields:
           log: 0
           failures: 0
-          progress: 0
           updated: 0
           after: 0
           status: 0
@@ -1028,8 +1027,8 @@ class JobCollectionBase extends Mongo.Collection
         status: "completed"
         result: result
         progress:
-          completed: 1
-          total: 1
+          completed: doc.progress.total or 1
+          total: doc.progress.total or 1
           percent: 100
         updated: time
 
@@ -1166,10 +1165,6 @@ class JobCollectionBase extends Mongo.Collection
         status: newStatus
         runId: null
         after: after
-        progress:
-          completed: 0
-          total: 1
-          percent: 0
         updated: time
       $push:
         failures:


### PR DESCRIPTION
Fixes: #214

I also made it so that when job fails, the last progress is left as it is. I think then one can see for example how far in was a job before it failed.