### PR TITLE
Support custom functions for scheduling repeated jobs

### DIFF
--- a/src/shared.coffee
+++ b/src/shared.coffee
@@ -797,9 +797,12 @@ class JobCollectionBase extends Mongo.Collection
     doc.retryUntil = time if doc.retryUntil < time
     doc.repeatUntil = time if doc.repeatUntil < time
 
+    if @scheduleRepeat? doc
+      # There is a custom hook to process repeatWait defined, and it returned true
+      # to signal that it processed the doc (potentially setting doc.after to a new value).
     # If doc.repeatWait is a later.js object, then don't run before
     # the first valid scheduled time that occurs after doc.after
-    if @later? and typeof doc.repeatWait isnt 'number'
+    else if @later? and typeof doc.repeatWait isnt 'number'
       unless next = @later?.schedule(doc.repeatWait).next(1, doc.after)
         console.warn "No valid available later.js times in schedule after #{doc.after}"
         return null


### PR DESCRIPTION
Provides a way to hook into computing `after` when scheduling repeated jobs. It could be used to for example configure timezones.