### PR TITLE
Make sure jobs are scheduled after doc.after

### DIFF
--- a/src/shared.coffee
+++ b/src/shared.coffee
@@ -800,7 +800,10 @@ class JobCollectionBase extends Mongo.Collection
     # If doc.repeatWait is a later.js object, then don't run before
     # the first valid scheduled time that occurs after doc.after
     if @later? and typeof doc.repeatWait isnt 'number'
-      unless next = @later?.schedule(doc.repeatWait).next(1, doc.after)
+      # Using a workaround to find next time after doc.after.
+      # See: https://github.com/vsivsi/meteor-job-collection/issues/217
+      schedule = @later?.schedule(doc.repeatWait)
+      unless schedule and next = schedule.next(2, schedule.prev(1, doc.after))[1]
         console.warn "No valid available later.js times in schedule after #{doc.after}"
         return null
       nextDate = new Date(next)

--- a/test/job_collection_tests.coffee
+++ b/test/job_collection_tests.coffee
@@ -391,7 +391,7 @@ if Meteor.isServer
     jobType = "TestJob_#{Math.round(Math.random()*1000000000)}"
     job = new Job(testColl, jobType, {some: 'data'})
       .repeat({
-        until: new Date(new Date().valueOf() + 2500),
+        until: new Date(new Date().valueOf() + 3500),
         schedule: testColl.later.parse.text("every 1 second")})
       .delay(1000)
     job.save (err, res) ->


### PR DESCRIPTION
Fixes: #217.

Even tests were showing this issue. Previously, job ran at 1000 ms and 2000 ms, so twice. But the first time was 1000 ms, this is wrong according to documentation. According to documentation job should be scheduled at first valid time **after** 1000 ms. That is 2000 ms.